### PR TITLE
feat: enable tracker configuration

### DIFF
--- a/client/index.ts
+++ b/client/index.ts
@@ -2,6 +2,11 @@ import { defineClientConfig } from '@vuepress/client'
 
 declare let __UMAMI_ANALYTICS_ID__: string
 declare let __UMAMI_ANALYTICS_SRC__: string
+declare let __UMAMI_ANALYTICS_HOST_URL__: string | null
+declare let __UMAMI_ANALYTICS_AUTO_TRACK__: boolean | null
+declare let __UMAMI_ANALYTICS_DO_NOT_TRACK__: boolean | null
+declare let __UMAMI_ANALYTICS_CACHE__: boolean | null
+declare let __UMAMI_ANALYTICS_DOMAINS__: string[] | null
 
 export default defineClientConfig({
   enhance: () => {
@@ -13,6 +18,30 @@ export default defineClientConfig({
     scriptTag.async = true
     scriptTag.src = __UMAMI_ANALYTICS_SRC__
     scriptTag.setAttribute('data-website-id', __UMAMI_ANALYTICS_ID__)
+    if (__UMAMI_ANALYTICS_HOST_URL__ !== null) {
+      scriptTag.setAttribute('data-host-url', __UMAMI_ANALYTICS_HOST_URL__)
+    }
+    if (__UMAMI_ANALYTICS_AUTO_TRACK__ !== null) {
+      scriptTag.setAttribute(
+        'data-auto-track',
+        '' + __UMAMI_ANALYTICS_AUTO_TRACK__,
+      )
+    }
+    if (__UMAMI_ANALYTICS_DO_NOT_TRACK__ !== null) {
+      scriptTag.setAttribute(
+        'data-do-not-track',
+        '' + __UMAMI_ANALYTICS_DO_NOT_TRACK__,
+      )
+    }
+    if (__UMAMI_ANALYTICS_CACHE__ !== null) {
+      scriptTag.setAttribute('data-cache', '' + __UMAMI_ANALYTICS_CACHE__)
+    }
+    if (__UMAMI_ANALYTICS_DOMAINS__ !== null) {
+      scriptTag.setAttribute(
+        'data-domains',
+        __UMAMI_ANALYTICS_DOMAINS__.join(','),
+      )
+    }
     document.body.appendChild(scriptTag)
   },
 })

--- a/readme.md
+++ b/readme.md
@@ -35,6 +35,8 @@ export default {
 
 ## Options
 
+For more details on the configuration of the tracker, see the [official documentation](https://umami.is/docs/tracker-configuration).
+
 ### id
 
 - Type: `string`
@@ -54,6 +56,66 @@ export default {
 - Details:
 
   Link to Umami analytics script.
+
+### hostUrl
+
+- Type: `string`
+
+- Required: `false`
+
+- Default value: `null`
+
+- Details:
+
+  Send data to this host instead of the one where the script is located.
+
+### autoTrack
+
+- Type: `boolean`
+
+- Required: `false`
+
+- Default value: `true`
+
+- Details:
+
+  Set to false to disable tracking all pageviews and events.
+
+### doNotTrack
+
+- Type: `boolean`
+
+- Required: `false`
+
+- Default value: `false`
+
+- Details:
+
+  Whether to respect the browser's Do Not Track setting.
+
+### cache
+
+- Type: `boolean`
+
+- Required: `false`
+
+- Default value: `false`
+
+- Details:
+
+  Whether to cache some data to improve performance. Be careful, it will use session storage, you may have to inform your users.
+
+### domains
+
+- Type: `string[]`
+
+- Required: `false`
+
+- Default value: `null`
+
+- Details:
+
+  Only run the tracker on the domains specified. With a `null` value, tracker is active everywhere.
 
 ![Umami tracking code](https://user-images.githubusercontent.com/5698350/190417132-fcedc6cb-636d-4634-a682-837a6f56c797.png)
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -3,6 +3,11 @@ import type { Plugin } from '@vuepress/core'
 import { getDirname, path } from '@vuepress/utils'
 
 interface UmamiAnalyticsPluginOptions {
+  doNotTrack?: boolean
+  autoTrack?: boolean
+  domains?: string[]
+  hostUrl?: string
+  cache?: boolean
   src: string
   id: string
 }
@@ -10,7 +15,15 @@ interface UmamiAnalyticsPluginOptions {
 let __dirname = getDirname(import.meta.url)
 
 export let umamiAnalyticsPlugin =
-  ({ src, id }: UmamiAnalyticsPluginOptions): Plugin =>
+  ({
+    doNotTrack,
+    autoTrack,
+    hostUrl,
+    domains,
+    cache,
+    src,
+    id,
+  }: UmamiAnalyticsPluginOptions): Plugin =>
   app => {
     let plugin = {
       name: 'vuepress-plugin-umami-analytics',
@@ -23,6 +36,11 @@ export let umamiAnalyticsPlugin =
     return {
       ...plugin,
       define: {
+        __UMAMI_ANALYTICS_DO_NOT_TRACK__: doNotTrack,
+        __UMAMI_ANALYTICS_AUTO_TRACK__: autoTrack,
+        __UMAMI_ANALYTICS_HOST_URL__: hostUrl,
+        __UMAMI_ANALYTICS_DOMAINS__: domains,
+        __UMAMI_ANALYTICS_CACHE__: cache,
         __UMAMI_ANALYTICS_SRC__: src,
         __UMAMI_ANALYTICS_ID__: id,
       },


### PR DESCRIPTION
According to Umami’s documentation found at
https://umami.is/docs/tracker-configuration, it is possible to
configure a tracker further than just its ID and source URL.

This commit adds the possibility to add such configuration with
optional members in the interface `UmamiAnalyticsPluginOptions`.